### PR TITLE
Add responsive WhatsApp floating button to About Us and Services pages

### DIFF
--- a/src/pages/AboutUs.html
+++ b/src/pages/AboutUs.html
@@ -242,6 +242,12 @@
     <!--Pie de pagina-->
     <footer-page></footer-page>
   </main>
+
+  <a href="https://wa.me/573024462007?text=Hola%20SMED%20Technology%2C%20quiero%20m%C3%A1s%20informaci%C3%B3n%20sobre%20sus%20servicios."
+    class="whatsapp-float" target="_blank" rel="noopener noreferrer" aria-label="Contactar por WhatsApp">
+    <i class="bx bxl-whatsapp"></i>
+  </a>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
     integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq"
     crossorigin="anonymous"></script>

--- a/src/pages/Services.html
+++ b/src/pages/Services.html
@@ -184,6 +184,12 @@
     </main>
   </div>
   <footer-page></footer-page>
+
+  <a href="https://wa.me/573024462007?text=Hola%20SMED%20Technology%2C%20quiero%20m%C3%A1s%20informaci%C3%B3n%20sobre%20sus%20servicios."
+    class="whatsapp-float" target="_blank" rel="noopener noreferrer" aria-label="Contactar por WhatsApp">
+    <i class="bx bxl-whatsapp"></i>
+  </a>
+
   <!-- Contenedor para particles.js -->
   <div id="particles-js"></div>
   <script src="../scripts/Particles.js"></script>

--- a/src/styles/AboutUs.css
+++ b/src/styles/AboutUs.css
@@ -595,3 +595,38 @@ p {
   }
 
 }
+/* Botón flotante de WhatsApp */
+.whatsapp-float {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  background: #25d366;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  text-decoration: none;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  z-index: 9999;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.whatsapp-float:hover {
+  transform: scale(1.08);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+  color: #fff;
+}
+
+@media (max-width: 768px) {
+  .whatsapp-float {
+    right: 16px;
+    bottom: 16px;
+    width: 52px;
+    height: 52px;
+    font-size: 1.8rem;
+  }
+}

--- a/src/styles/Services.css
+++ b/src/styles/Services.css
@@ -409,3 +409,39 @@
     transform: translateY(0);
   }
 }
+
+/* Botón flotante de WhatsApp */
+.whatsapp-float {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  width: 58px;
+  height: 58px;
+  border-radius: 50%;
+  background: #25d366;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2rem;
+  text-decoration: none;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.35);
+  z-index: 9999;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.whatsapp-float:hover {
+  transform: scale(1.08);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+  color: #fff;
+}
+
+@media (max-width: 768px) {
+  .whatsapp-float {
+    right: 16px;
+    bottom: 16px;
+    width: 52px;
+    height: 52px;
+    font-size: 1.8rem;
+  }
+}


### PR DESCRIPTION
### Motivation
- Añadir un botón de contacto por WhatsApp en las páginas de `AboutUs` y `Services` para ofrecer un canal de comunicación directo y móvil-friendly.

### Description
- Inserté un enlace flotante con `https://wa.me/573024462007?...` en `src/pages/AboutUs.html` y `src/pages/Services.html` usando `class="whatsapp-float"`, `target="_blank"`, `rel="noopener noreferrer"` y `aria-label` para accesibilidad y seguridad.
- Agregué estilos responsive para `.whatsapp-float` en `src/styles/AboutUs.css` y `src/styles/Services.css` que controlan posición fija, tamaño, sombra, transición y ajuste para pantallas móviles (`@media (max-width: 768px)`).
- Reutilicé la clase de icono existente `bx bxl-whatsapp` (Boxicons) y establecí `z-index` alto para que el botón permanezca visible sobre otros elementos.

### Testing
- Serví el proyecto localmente con `python3 -m http.server` y confirmé que las páginas cargan correctamente; la comprobación de servidor se ejecutó con éxito.
- Generé capturas de pantalla de `AboutUs.html` y `Services.html` usando Playwright (`mcp__browser_tools__run_playwright_script`) para verificar visibilidad y colocación del botón, y las capturas se generaron correctamente.
- Realicé una prueba rápida en navegador que abrió el botón y comprobó que la URL `wa.me` se abre en una nueva pestaña; la verificación automatizada se completó con éxito.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998d91803748331bcaa08cf45ec8c45)